### PR TITLE
Add privacy page for GitHub Pages

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy</title>
+</head>
+<body>
+    <h1>Privacy Policy</h1>
+    <p>This website for All Saints Church does not collect personal data from visitors. We use basic analytics to improve the site. If you have any questions about how your information is used, please contact us at info@allsaintsonline.example.</p>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add a privacy page for the GitHub Pages site
- place the page at `privacy/index.html` so it can be viewed at `/privacy/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844ab4011f8832997411014cb7f3d9b